### PR TITLE
packaging: fix dependency error for uilive lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/MisterOryon/Arma3HTS
 go 1.21.4
 
 require (
+	github.com/gosuri/uilive v0.0.4
 	github.com/pkg/sftp v1.13.6
 	github.com/spf13/cobra v1.8.0
 	golang.org/x/crypto v0.16.0
@@ -10,7 +11,6 @@ require (
 )
 
 require (
-	github.com/gosuri/uilive v0.0.4 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/kr/fs v0.1.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect


### PR DESCRIPTION
uilive libs is marked indirect require, but it is not true because it is used directly by the cli. uilive lib was therefore moved into direct require.